### PR TITLE
phase-0: pre-P10 setup — spec edits, doc scaffolds, Gradle T2 sweep, error-schema scaffold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md — Waterfall Compiler Project Context
+
+This file is read by Claude Code at session start. It tells the AI assistant what
+this project is, how to work in it, and what the load-bearing rules are.
+
+---
+
+## Project overview
+
+**Waterfall** is a compiled language targeting JavaScript, Python, and C. The
+compiler is written in Kotlin (JDK 17/21, Gradle multi-project build). The
+project is in **Phase 10** — a foundation refactor that introduces a typed IR,
+a central Verifier, and a typed SymbolTable. No observable language changes in P10;
+all existing examples must produce byte-identical output after P10.
+
+Key phases ahead: P10 (this one), P11 (type inference), P12 (sum types + match),
+P13 (LSP + package manager), P14 (generics), P16 (v1.0).
+
+---
+
+## Before writing any code
+
+1. **Read the spec first.** The load-bearing spec for any phase is in
+   `notes/PHASE-10-design.md` (current). Do not resolve ambiguities in code —
+   escalate them. The §6.2 escalation list names the cases explicitly.
+
+2. **Plan-back before coding.** For every non-trivial task, produce an ordered
+   commit list and wait for human ack before writing a line of implementation.
+
+3. **Run `./gradlew test` before committing.** Tests must stay green at every
+   commit. If a commit breaks tests, fix it before creating the next commit.
+
+---
+
+## Commit format
+
+- Imperative subject line: `feat: add WaterfallType sealed class` not `added WaterfallType`
+- Subject ≤ 72 characters
+- Body explains the *why*, not the *what*
+- **No `Co-Authored-By` trailers** (this repo uses no such convention)
+- **Never `--no-verify`** — if a hook fails, fix the underlying issue
+- One logical change per commit; don't combine unrelated work
+
+---
+
+## Cross-tree drift rule (F10)
+
+Spec edits and implementation commits must stay in sync. If you write code that
+resolves a spec ambiguity without editing the spec to remove that ambiguity, the
+spec is wrong and future sessions will re-discover the same ambiguity.
+
+**Protocol:** When you encounter an ambiguity:
+1. Stop. Do not silently resolve it in code.
+2. Surface it as a `// SPEC-AMBIGUITY: <description>` comment if at end-of-session.
+3. In a fresh session, edit the spec to remove the ambiguity, then re-plan.
+
+---
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `BUS-FACTOR.md` | Pipeline overview, decision log, how to cut a release |
+| `notes/PHASE-10-design.md` | Load-bearing spec for P10 (13 PITFALLs, §6.2 escalations) |
+| `notes/team-output/00-EXECUTION-PLAYBOOK.md` | Operational rhythm: spec-first loop, §3 verification triad, §7 PR template |
+| `notes/team-output/04-strategy.md` | Roadmap P10–P16, phase-exit checklists |
+| `SPEC.md` | Top-level vision + TOC (this file) |
+| `notes/VERIFICATION-DISCIPLINE.md` | Per-phase triad outcome log |
+| `IMPLEMENTATION-LOG.md` | Phase-kickoff + retrospective entries |
+
+---
+
+## Test suite
+
+```bash
+./gradlew test           # full suite (golden + unit + runtime-check)
+./gradlew build          # compile only
+UPDATE_GOLDEN=1 ./gradlew test --tests GoldenTests   # regenerate goldens
+```
+
+**Golden tests are the correctness oracle for P10.** Any golden change in P10 is
+a stop-the-line event — escalate immediately. Goldens should be byte-identical
+before and after P10.
+
+---
+
+## AI-augmented development disclosure
+
+This project is built with spec-first AI-augmented implementation per
+`notes/team-output/00-EXECUTION-PLAYBOOK.md` §1. The dominant risk is
+**"tests pass, code is wrong"** (failure mode #1 from the AI-research doc).
+Mitigations are the verification triad (§3): property tests at N=10000,
+differential oracle vs. goldens, and adversarial inputs (≥20 per phase).
+
+If you are an AI agent working in this repo: read the PITFALLs in
+`notes/PHASE-10-design.md` before writing any P10 code. Escalate the §6.2
+cases. Do not silently resolve ambiguities.

--- a/IMPLEMENTATION-LOG.md
+++ b/IMPLEMENTATION-LOG.md
@@ -1,0 +1,46 @@
+# IMPLEMENTATION-LOG.md
+
+Running log of phase kickoffs and retrospectives. One entry per phase.
+Templates from `notes/team-output/00-EXECUTION-PLAYBOOK.md` §2.
+
+---
+
+## Phase 10 kickoff — 2026-05-17
+
+- **Strategist roadmap entry:** `notes/team-output/04-strategy.md` §3, P10
+- **Predecessor phase exit tag:** `pre-p10-complete` (= `6435e2d`)
+- **Spec at implementation start:** `notes/PHASE-10-design.md` at commit
+  `<sha-of-Task-1-PR-merge>` _(placeholder — fill with the merge commit SHA
+  after the Task-1 PR lands on master)_
+- **Pre-review skeptic session:** completed; 2 FATAL + 6 RISK + 3 MINOR findings,
+  all folded into the spec before implementation began. Key changes: `void[]`
+  guard in `fromSourceText`, `forReturnType` adapter, `SourcePosition` data-class
+  requirement, `SymbolKind.Function` Pair-ordering KDoc, `fromSymbolTable`
+  companion-object fix.
+- **Open ambiguities entering implementation:** none — pending team-lead dispatch
+  after sub-task 5.1 closes (the spec is locked; any new ambiguities discovered
+  during 5.1 implementation will be logged here).
+- **Verification-design commitment (§3 triad):**
+  - Property invariants: SymbolTable lookup/declare/shadow (§2.7 cases as forAll
+    at N=10000); JoinAnalysis intersection correctness; IrLowering round-trip;
+    JsonRenderer schema round-trip
+  - Differential oracle: existing golden suite — zero golden diffs gate
+  - Adversarial input target: ≥20, location
+    `compiler/src/test/resources/adversarial/phase-10/`
+
+---
+
+## Phase 10 retrospective — (pending)
+
+_Filled when the phase-exit ritual completes (playbook §2). Template:_
+
+```
+## Phase 10 retrospective — {date}
+- Calendar weeks budgeted vs. actual: {bud} / {act}
+- Triad caught (count): properties {n_prop}, differential {n_diff}, adversarial {n_adv}
+- Skeptic findings on exit: {fatal} fatal / {risk} risk / {minor} minor
+- Spec edits during phase (count): {n}
+- Plan-mode iterations average: {x}
+- Carry-forward into phase 11: <list>
+- One sentence on what surprised: <text>
+```

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,88 @@
+# SPEC.md — Waterfall Language Specification (Living Artifact)
+
+**Status: living artifact — not v1.0 yet.** This file is the top-level entry point
+for the Waterfall language spec. It captures the vision and points to per-phase
+design documents. It will become a full language reference at v1.0 (P16).
+
+---
+
+## Vision
+
+Waterfall is a statically-typed language that compiles to **JavaScript, Python,
+and C**. It is designed for **library authors** who need to ship one implementation
+to three ecosystems without maintaining three separate codebases.
+
+Design philosophy:
+
+- **Gleam-vibe ergonomics**: immutable-by-default, clear error messages,
+  no hidden control flow, exhaustive pattern matching.
+- **Library-author first**: the FFI model (`@external`) lets a Waterfall
+  function delegate to a native implementation per target; the type system
+  ensures the Waterfall call-site is well-typed regardless of which target
+  is active.
+- **Zero-dependency output**: compiled artifacts are idiomatic JS/Python/C —
+  no runtime library, no bundler required.
+
+Target user: a developer who wants to write a parsing library, a serialization
+library, or a data-structure library *once* and publish it to npm, PyPI, and a
+C header simultaneously.
+
+---
+
+## Current language features (P10 baseline)
+
+- Scalar types: `int`, `dec`, `bool`, `char`; array types: `int[]`, `char[]`, etc.
+- Typed and inferred (`x :=`) variable declarations; `readonly` modifier
+- Functions with typed parameters and return types; recursion
+- `if`/`elif`/`else`, `while`, `for` (iterator-style)
+- `readonly x` flow-sensitive freeze statement (Form B)
+- Function calls (local, module-qualified, object-method)
+- Array literals and indexing; bundle literals
+- Lambdas (single-expression body)
+- Module system (one module per file)
+
+---
+
+## Roadmap (phase → feature)
+
+| Phase | Key deliverables | Spec doc |
+|---|---|---|
+| **P10** (current) | Typed IR, typed SymbolTable, central Verifier, JSON-first errors | `notes/PHASE-10-design.md` |
+| P11 | Type inference (`:=`), condition type-checking (`bool` only) | TBD |
+| P11.5 | C backend execution oracle; cross-target runtime consistency | TBD |
+| P12 | Sum types + `match`, exhaustiveness, `@external` enforcement | TBD |
+| P13 | LSP, stdlib coherence, package manager (`wfpm`) | TBD |
+| P14 | Generics (monomorphization) | TBD |
+| P15 | `Vec<T>`, `Map<K, V>` stdlib | TBD |
+| P16 | v1.0 — spec freeze, full adversarial review, publishing pipeline | TBD |
+
+Full roadmap with phase-exit checklists: `notes/team-output/04-strategy.md` §3.
+
+---
+
+## Per-phase design documents
+
+Each phase has a dedicated design doc in `notes/`:
+
+- `notes/PHASE-10-design.md` — current; load-bearing spec with 13 PITFALLs and
+  §6.2 escalation list. Read this before any P10 implementation work.
+
+Future phases will add `notes/PHASE-11-design.md`, etc. Each doc is locked at a
+commit before implementation begins (`phase-N-spec-locked` tag) and carries a
+tracked-delta log for any mid-implementation spec changes.
+
+---
+
+## Error code registry
+
+Stable error codes are defined in `notes/error-schema-v1.json`. The `WF1xxx`
+range covers P10-era errors; `WF2xxx` covers P12-era (`@external`, sum types);
+etc. Codes are stable across versions; renaming a `VerifyError` class is fine,
+changing its code is a breaking change.
+
+---
+
+*This document is maintained alongside the implementation. Edit it when the
+language adds a feature or when a design decision becomes canonical. The goal
+is that a new contributor can read SPEC.md + BUS-FACTOR.md and know where
+to look for everything else.*

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,9 @@ configure(subprojects) {
     apply plugin: 'org.jetbrains.kotlin.jvm'
     apply plugin: 'idea'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
+    java {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+    }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
         compilerOptions {

--- a/compiler/src/main/resources/error-schema-v1.json
+++ b/compiler/src/main/resources/error-schema-v1.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://waterfall-lang.dev/schemas/error-v1.json",
+  "title": "Waterfall Compiler Error v1",
+  "description": "Schema for a single JSONL error line emitted by the Waterfall compiler on stderr. See notes/PHASE-10-design.md §4.8 for field semantics and the code-allocation table.",
+  "type": "object",
+  "required": ["schemaVersion", "severity", "code", "message", "primaryLocation"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "description": "Schema version. Currently 1. Bumped on any breaking change to this format.",
+      "const": 1
+    },
+    "severity": {
+      "description": "Error severity. P10 ships only 'error'. 'warning' reserved for P11+ friendly-errors.",
+      "enum": ["error", "warning"]
+    },
+    "code": {
+      "description": "Stable error code. Consumers switch on this, never on message. See code-allocation table in PHASE-10-design.md §4.8.",
+      "type": "string",
+      "pattern": "^WF[0-9]+$"
+    },
+    "message": {
+      "description": "One-sentence canonical error message. Plain prose, no embedded formatting.",
+      "type": "string"
+    },
+    "primaryLocation": {
+      "description": "Source location where the error is anchored.",
+      "$ref": "#/$defs/sourceLocation"
+    },
+    "relatedInfo": {
+      "description": "Optional pointers to other source positions the error references (e.g., previous declaration site). Omit or use empty array when none.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["message", "location"],
+        "additionalProperties": false,
+        "properties": {
+          "message": {
+            "description": "Short prose describing what this related location means.",
+            "type": "string"
+          },
+          "location": {
+            "$ref": "#/$defs/sourceLocation"
+          }
+        }
+      }
+    },
+    "suggestedFix": {
+      "description": "One-line 'what to try' hint for the human renderer. null when the verifier has no suggestion.",
+      "type": ["string", "null"]
+    },
+    "tags": {
+      "description": "Reserved for LSP-style tags (e.g., 'unnecessary', 'deprecated'). Empty array in v1.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "$defs": {
+    "sourceLocation": {
+      "description": "A location in a Waterfall source file. line is 1-based; column is 0-based (matching ANTLR charPositionInLine). endLine/endColumn are optional; when omitted the consumer treats the location as a single-character span.",
+      "type": "object",
+      "required": ["file", "line", "column"],
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "description": "Path to the source file, as passed on the command line.",
+          "type": "string"
+        },
+        "line": {
+          "description": "1-based line number.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "column": {
+          "description": "0-based column offset (ANTLR charPositionInLine convention).",
+          "type": "integer",
+          "minimum": 0
+        },
+        "endLine": {
+          "description": "1-based end line (inclusive). Optional.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "endColumn": {
+          "description": "0-based end column (exclusive). Optional.",
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/notes/PHASE-10-design.md
+++ b/notes/PHASE-10-design.md
@@ -13,7 +13,7 @@ This document is the spec for Phase 10. It closes audit debts D1 (no IR), D2 (sy
 
 It is written to be implemented by an AI agent working with a senior operator (Aaron) doing review. Every section is detailed enough that an implementer should not have to guess. Where ambiguity remains, look for the **PITFALL** callouts — those are the failure modes that hit AI implementers in the public case studies (Klabnik's hardcoded instruction sizes, Anthropic's verifier overfitting). Read those before writing any code in the affected section.
 
-If you are the AI implementer: **escalate** the listed cases under "Section 7 — Escalation list" to human review instead of resolving silently.
+If you are the AI implementer: **escalate** the listed cases under "§6.2 — Escalation list" to human review instead of resolving silently.
 
 ---
 
@@ -102,7 +102,8 @@ sealed class WaterfallType {
          */
         fun fromSourceText(text: String): WaterfallType {
             if (text.startsWith("?")) return ErrorType(text)
-            val base = if (text.endsWith("[]")) text.dropLast(2) else text
+            val isArray = text.endsWith("[]")
+            val base = if (isArray) text.dropLast(2) else text
             val baseType = when (base) {
                 "int"  -> IntType
                 "dec"  -> DecType
@@ -111,15 +112,34 @@ sealed class WaterfallType {
                 "void" -> VoidType
                 else   -> return ErrorType(text)
             }
-            return if (text.endsWith("[]")) ArrayType(baseType) else baseType
+            // `void[]` (and `void[][]+`) is never a valid type — `void` is a return-only
+            // marker, not a value type that can be put in an array. The verifier-level
+            // PITFALL #1 covers bare `void x = ...`; this guard covers the array case
+            // at the parser level so `ArrayType(VoidType)` is structurally unconstructible.
+            if (isArray && baseType === VoidType) return ErrorType(text)
+            return if (isArray) ArrayType(baseType) else baseType
         }
+
+        /**
+         * Canonical adapter for nullable inputs (e.g., `FunctionImplementationData.returnType: String?`).
+         * Returns [VoidType] when `text` is null — matching today's `returnType ?: "void"` semantics
+         * but without round-tripping through [fromSourceText] ("void"). Non-null inputs go through
+         * [fromSourceText] verbatim.
+         *
+         * The §5.2 callsites at `FunctionImplementationData.verify` (line 35, self-decl for recursion)
+         * MUST use this method, not `fromSourceText(returnType ?: "void")` — the latter is forbidden
+         * because it introduces a string-bridge ambiguity (today the string-bridged path agrees with
+         * the helper only by coincidence with the §1.2 guard on `void[]`).
+         */
+        fun forReturnType(text: String?): WaterfallType =
+            if (text == null) VoidType else fromSourceText(text)
     }
 }
 ```
 
-**PITFALL #1** — The `void` case. Today `FunctionImplementationData.verify` at line 35 stores `returnType ?: "void"` in the symbol table. That string `"void"` is the same string the audit calls inconsistent (Section 3, `PrimitiveTypes`). Under the new scheme `VoidType` is a first-class variant of `WaterfallType`. `PrimitiveTypes.ALL` still does not contain `"void"`, which is correct because `void` is *not* a value type — it's only a return type. The verifier must reject `void x = ...` declarations (this was implicit before; make it explicit). Escalate if you discover any other site that conflated `"void"` with primitive types.
+**PITFALL #1** — The `void` case. Today `FunctionImplementationData.verify` (at the self-declaration call on line 35) stores `returnType ?: "void"` in the symbol table. That string `"void"` is the same string the audit calls inconsistent (Section 3, `PrimitiveTypes`). Under the new scheme `VoidType` is a first-class variant of `WaterfallType`. `PrimitiveTypes.ALL` still does not contain `"void"`, which is correct because `void` is *not* a value type — it's only a return type. The verifier must reject `void x = ...` declarations (this was implicit before; make it explicit). **Sub-task ownership**: the explicit rejection lands in §5.3 (verifier package) as a new `VerifyError.VoidNotAValueType` variant emitted from `StatementVerifier.verifyTypedVarDecl` when the declared type is `WaterfallType.VoidType`. The array case `ArrayType(VoidType)` is handled at the parser level by the §1.2 `fromSourceText` guard — `void[]` returns `ErrorType("void[]")`, so the §5.3 rejection only needs to cover `WaterfallType.VoidType`, not `WaterfallType.ArrayType(WaterfallType.VoidType)`. §5.1 ships `VoidType` as a constructible variant; nothing in §5.1 enforces the rejection. Escalate if you discover any other site that conflated `"void"` with primitive types.
 
-**PITFALL #2** — Don't add variants speculatively. The IR (Section 3) will need more type variants for records and sum types (P12), generics (P14). Those are *not* part of P10. Add them in their phases. Leaving them out now means `when (t)` matches are exhaustive at P10 and will get a compile error when new variants land — that's the desired error, it tells the implementer "you must handle this here too."
+**PITFALL #2** — Don't add variants speculatively. The IR (Section 3) will need more type variants for records and sum types (P12), generics (P14). Those are *not* part of P10. Add them in their phases. Leaving them out now means `when (t)` matches are exhaustive at P10 and will get a compile error when new variants land — that's the desired error, it tells the implementer "you must handle this here too." **Function types as first-class values** (for higher-order lambdas) are deferred. P10 lambdas remain represented structurally via the existing `LambdaFunctionData`, not as `WaterfallType.FunctionType` values. If you find yourself wanting to add a function-type variant for lambdas, stop — that's P12 (with sum types) or P14 (with generics).
 
 ### 1.3 `SymbolKind` — the kind discriminator (closes D6)
 
@@ -153,10 +173,20 @@ sealed class SymbolKind {
      * available from P10 onward.
      */
     data class Function(
+        /**
+         * Parameter list. `Pair` is `kotlin.Pair` (not the custom
+         * `com.aaroncoplan.waterfall.parser.Pair`). Field convention: **first = name, second = type**.
+         * This ordering is the OPPOSITE of the legacy `(type, name)` convention used in
+         * `FunctionImplementationData.typedArguments` and `LambdaFunctionData` — when §5.2
+         * migrates those callsites, swap the order at the boundary. Per §5.1 → §5.2 contract
+         * below, do NOT introduce a `TypedArgument` data class in §5.1.
+         */
         val parameters: List<Pair<String, com.aaroncoplan.waterfall.compiler.typesystem.WaterfallType>>
     ) : SymbolKind()
 }
 ```
+
+**Sub-task 5.1 → 5.2 contract on `parameters`.** §5.1 ships `SymbolKind.Function.parameters` typed as `List<Pair<String, WaterfallType>>` exactly as shown above. §5.2 may refactor this to `List<TypedArgument>` where `TypedArgument(name, type, sourcePosition)` is the small data class proposed in §7.3 — that refactor is needed to satisfy PITFALL #8 (per-argument source positions). §5.1 does NOT pre-introduce `TypedArgument`. **Specifically, §5.1 MUST NOT add any field to `SymbolKind.Function` beyond `parameters` — including a parallel `List<SourcePosition>` for arg positions.** Per-argument positions are §5.2's call; pre-introducing a parallel position list duplicates the eventual `TypedArgument` data and creates a refactor-on-refactor situation. The decision to refactor is made during §5.2's plan-mode loop, not §5.1's; if §5.2 chooses an alternative resolution to PITFALL #8 (e.g., position-as-fourth-Pair-field via a `Triple`-style wrapper), `SymbolKind.Function` is updated then. Implementers of §5.1 should NOT speculatively introduce `TypedArgument` based on §7.3 alone.
 
 **PITFALL #3** — Don't fold the function-signature info into `SymbolInfo.type`. The Audit Section 3 on `PrimitiveTypes` notes that today the function name is declared with its *return type* as the info value. That's stringly-typed and ambiguous (`add: "int"` is indistinguishable from a variable `int add = 0`). The fix is structural: store `kind = SymbolKind.Function(params)` and store the *return type* in `SymbolInfo.type`. This makes "what kind of thing is this?" answerable in one lookup.
 
@@ -175,13 +205,19 @@ import com.aaroncoplan.waterfall.compiler.typesystem.WaterfallType
  * `SymbolTable.kt:5` (audit D2).
  *
  * Immutable. To "change" a binding's readonly state without a parent-scope
- * write (the §2c shadow model), the [SymbolTable] uses [SymbolTable.markReadonlyLocal];
- * to commit a flow-sensitive promotion at a branch join, it uses [SymbolTable.commitReadonly].
+ * write (the §2c shadow model), the SymbolTable uses markReadonlyLocal (added in §5.2);
+ * to commit a flow-sensitive promotion at a branch join, it uses commitReadonly (also §5.2).
  * Both produce new SymbolInfo values via `.copy(isReadonly = true)` — the original
- * is never mutated in place.
+ * is never mutated in place. (KDoc cross-reference links are deliberately written as
+ * plain prose here to avoid stale Dokka links during the §5.1 → §5.2 interim state.)
  *
- * Equality and hashCode are structural (data class). Two SymbolInfos are equal
- * iff every field is equal, including source position.
+ * Equality and hashCode are structural (data class). Two SymbolInfos are equal iff every
+ * field is equal, including source position. This requires `SourcePosition` to also
+ * provide structural equality — §5.1 converts `SourcePosition` to a data class (see §5.1
+ * Files changed). Without that change, `.copy(isReadonly = true)` would still work (the
+ * `sourcePosition` reference is shared), but two SymbolInfo values reconstructed from the
+ * same source location via different ANTLR walks would compare unequal, silently breaking
+ * test fixtures and any future invalidation logic.
  */
 data class SymbolInfo(
     /** The declared (or inferred at P11+) type. For functions this is the
@@ -212,7 +248,7 @@ data class SymbolInfo(
 
 ### 2.1 Why
 
-Today (`SymbolTable.kt:21`) `lookup` is `private`. No external caller can ask "is `x` readonly?" or "what's the type of `x`?". This blocks the type-inference work at P11, the call-site type-checking at P11, and the Form B `readonly` enforcement (audit Section 4).
+Today (`SymbolTable.kt:21`) `lookup` is `internal` and contractually treated as private — no production code outside `symboltables/` calls it. (Phase 0 PR2 widened from `private` to `internal` so the verifier-const-enforcement work could land; see commit `ea4e1cc`.) P10 widens to `public` and stabilizes the contract. This unblocks the type-inference work at P11, the call-site type-checking at P11, and the Form B `readonly` enforcement (audit Section 4).
 
 The full new API is below. Stick to these signatures; don't add helpers speculatively.
 
@@ -1082,7 +1118,7 @@ The implementer should encode the mappings below as a `when` over the `*Data` su
 | `UntypedVariableDeclarationAndAssignmentData` | `IrStatement.UntypedVarDecl` | `inferredType` from `WaterfallType.fromSourceText(.inferredType)` |
 | `VariableAssignmentData` | `IrStatement.VarAssignment` | `op`, `value` mapped directly |
 | `IncrementStatementData` | `IrStatement.IncrementStatement` | `op` directly |
-| `ReadonlyPromotionData` (new, from Piece 2 design) | `IrStatement.ReadonlyPromotion` | `name` only |
+| `ReadonlyPromotionData` (NOT in P10 — Piece 2 lands in P12) | `IrStatement.ReadonlyPromotion` | Forward-looking row. The `*Data` class does not exist in the P10 codebase; P10's lowering `when` does NOT include this case. The IR variant `IrStatement.ReadonlyPromotion` ships in P10 so the IR shape is stable for P12, but no P10 input produces it. P12 adds the parser/AST + lowering case + verifier handler together. |
 | `IfBlockData` | `IrStatement.IfBlock` | recursively lower bodies and conditions |
 | `WhileBlockData` | `IrStatement.WhileBlock` | recursively lower |
 | `ForBlockData` | `IrStatement.ForBlock` | preserve `iteratorName` and `collectionName` |
@@ -1145,7 +1181,7 @@ interface CodeGenerator {
 }
 ```
 
-**PITFALL #10** — Don't try to keep the old interface alive in parallel with the new one. The audit's D4 (backend duplication) is a real issue, but it's a *separate* problem from D1. P10 is just the IR migration. After P10, all four backends consume IR; addressing D4 (e.g., a shared "block-of-statements" helper) is post-P10 work.
+**PITFALL #10** — Don't try to keep the old interface alive in parallel with the new one. The audit's D4 (backend duplication) is a real issue, but it's a *separate* problem from D1. P10 is just the IR migration. After P10, all three backends consume IR; addressing D4 (e.g., a shared "block-of-statements" helper) is post-P10 work.
 
 ---
 
@@ -1266,16 +1302,22 @@ sealed class VerifyError {
             "(declared at ${declarationPosition.generateMessage()})."
     }
 
-    /**
-     * Catch-all for converting a symbol-table-level error into a verifier
-     * error. Used when [SymbolTable.declare] returns a Failure.
-     */
-    fun fromSymbolTable(e: DuplicateDeclarationError): DuplicateDeclaration =
-        DuplicateDeclaration(
-            name = e.name,
-            previousPosition = e.previouslyDeclaredAt,
-            primaryPosition = e.attemptedAt
-        )
+    companion object {
+        /**
+         * Catch-all for converting a symbol-table-level error into a verifier
+         * error. Used when [SymbolTable.declare] returns a Failure. Lives in
+         * the companion object so the §4.5 callsite `VerifyError.fromSymbolTable(...)`
+         * resolves correctly (an instance method would require a pre-existing
+         * VerifyError to dispatch on, which makes no contextual sense at this
+         * call site).
+         */
+        fun fromSymbolTable(e: DuplicateDeclarationError): DuplicateDeclaration =
+            DuplicateDeclaration(
+                name = e.name,
+                previousPosition = e.previouslyDeclaredAt,
+                primaryPosition = e.attemptedAt
+            )
+    }
 }
 
 /**
@@ -2126,7 +2168,7 @@ class IrLoweringPropertyTest {
 - [ ] Gradle dependency on `kotest-property` and `kotest-runner-junit4` added.
 - [ ] At least one property test per major subsystem: SymbolTable (the walk-depth boundary), JoinAnalysis (intersection over generated branches), JsonRenderer (schema round-trip).
 - [ ] Property tests run as part of `./gradlew test` — no separate command needed.
-- [ ] Each property test has at least 100 iterations by default; failure produces a *shrunk* counterexample (Kotest does this automatically).
+- [ ] Each property test has at least 100 iterations by default; failure produces a *shrunk* counterexample (Kotest does this automatically). Per `notes/team-output/00-EXECUTION-PLAYBOOK.md` §3 Leg 1, **production target is N=10000** for SymbolTable / JoinAnalysis / IR-shape invariants; N=1000 acceptable only for properties that compile a generated program and run it through a backend (call this out in the test KDoc). The §4.9 worked example uses `checkAll(100, ...)` solely for spec-doc legibility — implementer uses N=10000 unless the per-test rationale documents otherwise.
 
 #### Strategy implication
 
@@ -2141,11 +2183,19 @@ P10's six sub-tasks land in order. Tests stay green at every step; if they don't
 - `compiler/src/main/kotlin/com/aaroncoplan/waterfall/compiler/symboltables/SymbolKind.kt`
 - `compiler/src/main/kotlin/com/aaroncoplan/waterfall/compiler/symboltables/SymbolInfo.kt`
 
-**Files changed:** none yet. `SymbolTable.kt` still stores `Any?` at this step.
+**Files changed:**
+- `compiler/src/main/kotlin/com/aaroncoplan/waterfall/compiler/statements/helpers/SourcePosition.kt` — convert from `class SourcePosition internal constructor(...)` (with three `private val` fields) to `data class SourcePosition(val fileName: String, val line: Int, val column: Int)` (public primary constructor; fields exposed as `val`). The existing `generateMessage()` method is preserved verbatim. Three structural consequences:
+  1. Structural `equals`/`hashCode` — load-bearing for `SymbolInfo`'s data-class equality (otherwise reconstructed SymbolInfos compare unequal even when describing the same binding).
+  2. Public constructor — needed by §5.2's per-argument position synthesis (PITFALL #8) and by test fixtures (every §2.7 SymbolTable test constructs a SourcePosition literal).
+  3. Field visibility widens from `private val` to `val`. Today's only field-reader is `generateMessage()` (same class); no production code outside the class reads the fields. Test fixtures will start reading them — that's intentional.
 
-**Expected test impact:** none — these are new files unused by anything yet.
+  Compile-impact: the one production caller — `TranslatableStatement.kt:10`'s `SourcePosition(ctx.start.text, ctx.start.line, ctx.start.charPositionInLine)` — continues to compile unchanged.
 
-**Sanity check:** `./gradlew build` passes.
+`SymbolTable.kt` still stores `Any?` at this step — that migration is §5.2.
+
+**Expected test impact:** existing tests pass unchanged (the SourcePosition change is structurally equivalent for the single production caller). New tests are not added at §5.1 — the §2.7 SymbolTable tests land with §5.2.
+
+**Sanity check:** `./gradlew build` passes; `./gradlew test` is byte-identical to baseline.
 
 ### Sub-task 5.2 — Migrate `SymbolTable` to typed storage + public `lookup` + shadow API
 
@@ -2154,10 +2204,10 @@ P10's six sub-tasks land in order. Tests stay green at every step; if they don't
 - `compiler/src/main/kotlin/com/aaroncoplan/waterfall/compiler/symboltables/DuplicateDeclarationException.kt` (delete; replaced by `DuplicateDeclarationError` and `DeclareResult`).
 
 **Callsites updated** (these are the only ones today):
-- `compiler/.../statements/TypedVariableDeclarationAndAssignmentData.kt:30` — wrap declare in DeclareResult handling.
-- `compiler/.../statements/UntypedVariableDeclarationAndAssignmentData.kt:25` — same.
-- `compiler/.../statements/FunctionImplementationData.kt:35` — self-decl, wrap as Function.
-- `compiler/.../statements/FunctionImplementationData.kt:47` — per-arg declare.
+- `compiler/.../statements/TypedVariableDeclarationAndAssignmentData.kt:30` — wrap declare in DeclareResult handling. **MUST use `kind = SymbolKind.Variable`**.
+- `compiler/.../statements/UntypedVariableDeclarationAndAssignmentData.kt:25` — same. **MUST use `kind = SymbolKind.Variable`**.
+- `compiler/.../statements/FunctionImplementationData.kt:35` — self-decl, wrap as Function. **MUST use `kind = SymbolKind.Function(parameters)`** with `parameters` constructed as `List<Pair<String, WaterfallType>>` per the §1.3 ordering (name first, type second). Use `WaterfallType.forReturnType(returnType)` for the return type (handles the `String?` → `WaterfallType` conversion canonically). **MUST set `isReadonly = true`** (functions are implicitly readonly — PITFALL #7).
+- `compiler/.../statements/FunctionImplementationData.kt:47` — per-arg declare. **MUST use `kind = SymbolKind.Argument`** (NOT `Variable`). The kind discriminator only earns its keep if the per-arg call site sets it correctly at introduction time; collapsing it into `Variable` silently throws away the information P10's audit-D6 closure was supposed to provide.
 
 For each, the existing `verify` body now wraps the `declare` call in a check for `DeclareResult.Failure`. The existing string error messages are translated 1:1 to `VerificationResult(false, msg)` returns (the verify() method on Translatable still exists at this step — Section 4 separation lands in Sub-task 5.5).
 
@@ -2219,7 +2269,7 @@ This is the biggest single change. One backend at a time. The order to use:
 
 **Sanity check after each backend:** Run `./gradlew test --tests GoldenTests` filtered to the relevant target. All pass.
 
-After all four backends are migrated, `CodeGenerator.kt` itself updates (the interface signature change in Section 3.9).
+After all three backends are migrated, `CodeGenerator.kt` itself updates (the interface signature change in Section 3.9).
 
 **PITFALL #13** — The "produces the same output" check is *exactly* the verifier-overfitting failure mode the AI-research doc (07) warns about. The implementer will be tempted to write tests that the new IR-driven backend passes by construction, then declare victory. The honest test is: **goldens unchanged**. If the goldens have to change, something is wrong; if you find yourself updating a golden, **escalate**.
 
@@ -2331,7 +2381,7 @@ This is a phase-boundary question the strategist should weigh in on. P10 ships e
 
 The migration in §5.2 will touch every callsite of `SymbolTable.declare`. Three of those are inside `FunctionImplementationData.verify` which uses the custom `Pair<K, V>` class for `typedArguments`. If the per-argument source position fix (PITFALL #8) goes in, the `Pair<String, String>` for typedArguments becomes inadequate — it needs a third field for position. That's a small refactor of `FunctionImplementationData` that ripples into `LambdaFunctionData` (also stores `Pair<String, String>` for arg lists).
 
-Mitigation: introduce a small `TypedArgument(type, name, position)` data class in the `statements/` package and migrate both `FunctionImplementationData` and `LambdaFunctionData` to use it. The `Pair<K, V>` class itself stays (audit surprise #7 makes clear it's still used elsewhere; full removal is post-P10 cleanup).
+Mitigation: introduce a small `TypedArgument(name, type, sourcePosition)` data class in the `statements/` package and migrate both `FunctionImplementationData` and `LambdaFunctionData` to use it. The field ordering (name first, type second, position third) is canonical across §1.3, the §1.3 sub-task contract paragraph, and here — `SymbolKind.Function.parameters` and `TypedArgument` use the same ordering to make the §5.2 refactor mechanical. The `Pair<K, V>` class itself stays (audit surprise #7 makes clear it's still used elsewhere; full removal is post-P10 cleanup).
 
 ### 7.4 `VerifyError` will need rendering helpers at P11
 

--- a/notes/PHASE-10-design.md
+++ b/notes/PHASE-10-design.md
@@ -2193,9 +2193,12 @@ P10's six sub-tasks land in order. Tests stay green at every step; if they don't
 
 `SymbolTable.kt` still stores `Any?` at this step — that migration is §5.2.
 
-**Expected test impact:** existing tests pass unchanged (the SourcePosition change is structurally equivalent for the single production caller). New tests are not added at §5.1 — the §2.7 SymbolTable tests land with §5.2.
+**Expected test impact:** existing tests pass unchanged (the SourcePosition change is structurally equivalent for the single production caller). §5.1 also adds **one new test file** that exercises the new `WaterfallType` surface — the new code is callable from tests as soon as 5.1 lands, so testing it here (rather than waiting for §5.2 to wire it in) catches `fromSourceText` silent-resolution bugs at the lowest possible layer. The §2.7 SymbolTable tests still land with §5.2.
 
-**Sanity check:** `./gradlew build` passes; `./gradlew test` is byte-identical to baseline.
+**Files added (tests):**
+- `compiler/src/test/kotlin/com/aaroncoplan/waterfall/compiler/typesystem/WaterfallTypeTest.kt` — covers `WaterfallType.fromSourceText` happy paths (4 primitives + 4 arrays + bare `void`), every rejected case (`void[]`, `int[][]`, `?int`, uppercase, leading/trailing whitespace, empty, whitespace-only, unknown identifiers), `ErrorType.sourceText` preservation, and `render()` round-trip for valid types; plus `forReturnType(text: String?)` (null, int, void, int[], void[], empty). ~28 test cases.
+
+**Sanity check:** `./gradlew build` passes; `./gradlew test` is byte-identical to baseline *except* for the addition of `WaterfallTypeTest` (~28 new test cases, all green).
 
 ### Sub-task 5.2 — Migrate `SymbolTable` to typed storage + public `lookup` + shadow API
 

--- a/notes/VERIFICATION-DISCIPLINE.md
+++ b/notes/VERIFICATION-DISCIPLINE.md
@@ -1,0 +1,104 @@
+# VERIFICATION-DISCIPLINE.md
+
+Per-phase log of verification triad outcomes. Filled as each sub-task lands.
+See `notes/team-output/00-EXECUTION-PLAYBOOK.md` §3 for the triad design.
+
+The three legs per phase:
+
+| Leg | What it covers | Pass signal |
+|---|---|---|
+| **Property tests** (Kotest, N=10000) | Invariant-level correctness over generated inputs | No failing property at N=10000 |
+| **Differential oracle** | Byte-equivalent output vs. a named known-good | Zero golden diffs |
+| **Adversarial inputs** (≥20 per phase) | Edge cases and silent-resolution traps | No `compiler-broke` cases unfixed |
+
+---
+
+## Phase 10 — Foundation Refactor
+
+**Oracle:** existing golden suite (prior `*Data` AST emission + `GoldenTests`).
+Mechanism: for every example, old and new pipeline must produce byte-equivalent
+emission per target. Zero golden diffs is the gate.
+
+**Adversarial input location:** `compiler/src/test/resources/adversarial/phase-10/`
+
+### Sub-task 5.1 — WaterfallType, SymbolKind, SymbolInfo
+
+- Property tests: _pending_
+- Differential oracle: _pending_
+- Adversarial inputs: _pending_
+
+### Sub-task 5.2 — SymbolTable migration
+
+- Property tests: _pending_ (SymbolTable invariants from §2.7)
+- Differential oracle: _pending_ (goldens unchanged)
+- Adversarial inputs: _pending_
+
+### Sub-task 5.3 — Verifier package + JSON errors
+
+- Property tests: _pending_ (JoinAnalysis intersection, JsonRenderer round-trip)
+- Differential oracle: _pending_ (goldens unchanged)
+- Adversarial inputs: _pending_
+
+### Sub-task 5.4 — IR package + lowering pass
+
+- Property tests: _pending_ (IrLowering round-trip)
+- Differential oracle: _pending_ (goldens unchanged)
+- Adversarial inputs: _pending_
+
+### Sub-task 5.5 — Backend migration (JS → Python → C)
+
+- Property tests: _pending_
+- Differential oracle: _pending_ (goldens unchanged per backend)
+- Adversarial inputs: _pending_
+
+### Sub-task 5.6 — Remove old paths + phase exit
+
+- Property tests: _pending_ (full suite at N=10000)
+- Differential oracle: _pending_ (full golden suite)
+- Adversarial inputs: _pending_ (≥20 AI-generated, fresh session)
+
+### Phase 10 exit summary
+
+_Filled when phase-exit ritual completes (per playbook §2)._
+
+---
+
+## Phase 11 — Type inference + condition type-checking
+
+_Pending._
+
+---
+
+## Phase 11.5 — C execution oracle + cross-target consistency
+
+_Pending._
+
+---
+
+## Phase 12 — Sum types + match + @external
+
+_Pending._
+
+---
+
+## Phase 13 — LSP + package manager + stdlib coherence
+
+_Pending._
+
+---
+
+## Phase 14 — Generics (monomorphization)
+
+_Pending._
+
+---
+
+## Phase 15 — Vec<T>, Map<K, V> stdlib
+
+_Pending._
+
+---
+
+## Phase 16 — v1.0 freeze + full adversarial review
+
+_Pending._

--- a/notes/error-schema-v1.json
+++ b/notes/error-schema-v1.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://waterfall-lang.dev/schemas/error-v1.json",
+  "title": "Waterfall Compiler Error v1",
+  "description": "Schema for a single JSONL error line emitted by the Waterfall compiler on stderr. See notes/PHASE-10-design.md §4.8 for field semantics and the code-allocation table.",
+  "type": "object",
+  "required": ["schemaVersion", "severity", "code", "message", "primaryLocation"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "description": "Schema version. Currently 1. Bumped on any breaking change to this format.",
+      "const": 1
+    },
+    "severity": {
+      "description": "Error severity. P10 ships only 'error'. 'warning' reserved for P11+ friendly-errors.",
+      "enum": ["error", "warning"]
+    },
+    "code": {
+      "description": "Stable error code. Consumers switch on this, never on message. See code-allocation table in PHASE-10-design.md §4.8.",
+      "type": "string",
+      "pattern": "^WF[0-9]+$"
+    },
+    "message": {
+      "description": "One-sentence canonical error message. Plain prose, no embedded formatting.",
+      "type": "string"
+    },
+    "primaryLocation": {
+      "description": "Source location where the error is anchored.",
+      "$ref": "#/$defs/sourceLocation"
+    },
+    "relatedInfo": {
+      "description": "Optional pointers to other source positions the error references (e.g., previous declaration site). Omit or use empty array when none.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["message", "location"],
+        "additionalProperties": false,
+        "properties": {
+          "message": {
+            "description": "Short prose describing what this related location means.",
+            "type": "string"
+          },
+          "location": {
+            "$ref": "#/$defs/sourceLocation"
+          }
+        }
+      }
+    },
+    "suggestedFix": {
+      "description": "One-line 'what to try' hint for the human renderer. null when the verifier has no suggestion.",
+      "type": ["string", "null"]
+    },
+    "tags": {
+      "description": "Reserved for LSP-style tags (e.g., 'unnecessary', 'deprecated'). Empty array in v1.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "$defs": {
+    "sourceLocation": {
+      "description": "A location in a Waterfall source file. line is 1-based; column is 0-based (matching ANTLR charPositionInLine). endLine/endColumn are optional; when omitted the consumer treats the location as a single-character span.",
+      "type": "object",
+      "required": ["file", "line", "column"],
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "description": "Path to the source file, as passed on the command line.",
+          "type": "string"
+        },
+        "line": {
+          "description": "1-based line number.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "column": {
+          "description": "0-based column offset (ANTLR charPositionInLine convention).",
+          "type": "integer",
+          "minimum": 0
+        },
+        "endLine": {
+          "description": "1-based end line (inclusive). Optional.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "endColumn": {
+          "description": "0-based end column (exclusive). Optional.",
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/notes/team-output/04-strategy.md
+++ b/notes/team-output/04-strategy.md
@@ -259,7 +259,7 @@ I'll annotate where AUDIT-OPEN-QUESTIONS codes (G4, G5, U1–U3, C1–C7, T1–T
 **Effort: 2–3 weeks calendar (AI-augmented).** This is the most architecturally consequential phase and the one where verification design *cannot* be cut. The spec/plan-mode loop will likely consume 1 of those 3 weeks; implementation is the other 1–2. **The single biggest predictor of whether the rest of the roadmap compresses is whether P10's spec is precise enough that the AI doesn't silently resolve ambiguities.** If the spec is sloppy, P10 stretches and pollutes everything downstream.
 
 **Phase-exit checklist:**
-- [ ] All four backends consume the new IR, not the `*Data` AST.
+- [ ] All three backends consume the new IR, not the `*Data` AST.
 - [ ] Verifier separated; no `verify()` on `*Data`.
 - [ ] `SymbolTable.lookup` public; in-test inspection demonstrated.
 - [ ] CI green; all goldens unchanged (differential test).
@@ -362,7 +362,7 @@ I'll annotate where AUDIT-OPEN-QUESTIONS codes (G4, G5, U1–U3, C1–C7, T1–T
 **Effort: 2–3 weeks calendar (AI-augmented).** Sum types and match are the most-implemented feature pattern in modern compilers — there's abundant training data, and AI compresses well here. `@external` is the novel-feature work and carries the most risk of failure mode #4 (silent spec resolution) — its spec needs to be tight.
 
 **Phase-exit checklist:**
-- [ ] Sum types and `match` work end-to-end on all four backends.
+- [ ] Sum types and `match` work end-to-end on all three backends.
 - [ ] Exhaustiveness check rejects missing cases.
 - [ ] Multi-statement lambda bodies.
 - [ ] `@external` works across JS/Python/C with correct visibility semantics.


### PR DESCRIPTION
## Summary

Pre-P10 cleanup PR. Carry-forward items from Phase 0 + the P10 phase-exit prerequisite docs + the JSON-error schema scaffold. **No Kotlin source changes** — docs, build config, and spec only. Tests stay green and goldens are byte-identical.

Branch is `phase-0/pre-p10-setup-v2` because the initial push (`phase-0/pre-p10-setup`) was accidentally cut from a commit 16 ahead of Phase 0 PR1 and would have silently reverted Phase 0; broken branch has been deleted from the remote.

## Commits (9, in landing order)

1. `2de9257 spec: apply pre-implementation edits to PHASE-10-design.md` — folds in (a) the four carry-forward edits I (Aaron) noted in the kickoff brief, (b) the ten skeptic-driven fixes from the fresh-context skeptic pre-review of §1 (`void[]` guard, `forReturnType` nullable adapter, `SymbolKind.Function.parameters` ordering KDoc, `SourcePosition` data-class requirement, PITFALL #1 expansion, PITFALL #2 no-FunctionType note, KDoc forward-ref scrub, §2.1 internal-vs-private fix, §3.8 ReadonlyPromotionData row, §4.9 N=10000 clarification), (c) the §5.1/§5.2 callsite explicit-kind requirements, and (d) the `VerifyError.fromSymbolTable` companion-object fix (Tester finding B1).
2. `d01800d spec: fix "four backends" → "three backends" in 04-strategy.md` — line 262 + 365; legacy was dropped in Phase 0 PR #12.
3. `eea32e8 build: use java{} block for sourceCompatibility to clear Gradle 9 deprecation` — only deprecation warning, now zero.
4. `9f1725f docs: add CLAUDE.md at repo root` — project context, commit format, cross-tree drift rule, AI-augmented disclosure.
5. `bd77f28 docs: add SPEC.md at repo root` — vision stub + TOC; living artifact.
6. `ec9094b docs: add notes/VERIFICATION-DISCIPLINE.md` — per-phase triad outcome template (P10–P16, empty until each sub-task lands).
7. `d715931 docs: add IMPLEMENTATION-LOG.md with P10 phase-kickoff entry` — predecessor tag, spec SHA placeholder (TBD post-merge), empty open-ambiguities (lead will dispatch post-5.1).
8. `ae3a601 spec: scaffold error-schema-v1.json (JSON Schema Draft 2020-12)` — at `notes/` and `compiler/src/main/resources/`. Schema body verbatim per §4.8.
9. `d571dd8 spec: add WaterfallTypeTest.kt as §5.1 deliverable` — adds Tester's 28-case unit test file as an explicit §5.1 deliverable (was originally "no tests added"); test file itself will be authored on the 5.1 branch.

## Test plan

- [x] `./gradlew test` green (no Kotlin code changes, so no new test paths; existing 167 tests + goldens unchanged)
- [x] `./gradlew build --warning-mode all 2>&1 | grep -i deprecat` returns empty (Gradle T2 swept)
- [x] `LegacyTextBackend.kt` absent (Phase 0 PR #12 preserved)
- [x] `BUS-FACTOR.md` present (Phase 0 PR #14 preserved)

## Workflow context

This PR is the prerequisite-setup before P10 sub-task 5.1 begins (sub-task 5.1 is "Introduce WaterfallType, SymbolKind, SymbolInfo" per `notes/PHASE-10-design.md` §5.1). The spec edits in commit 1 close the spec-first plan-mode loop for 5.1 (3 iterations to convergence) plus the fresh-context skeptic findings (2 FATAL + 6 RISK + 3 MINOR, all addressed). After this lands, 5.1 implementation can begin against a stable spec.

Once merged, the `<sha>` placeholder in `IMPLEMENTATION-LOG.md` should be filled with the merge commit SHA as the first commit of the 5.1 branch.